### PR TITLE
feat: unread icon logic

### DIFF
--- a/app/src/main/java/com/xinto/opencord/db/dao/ChannelsDao.kt
+++ b/app/src/main/java/com/xinto/opencord/db/dao/ChannelsDao.kt
@@ -15,7 +15,6 @@ interface ChannelsDao {
     )
     fun insertChannels(channels: List<EntityChannel>)
 
-    // --------------- Inserts ---------------
     @Query("UPDATE channels SET is_pins_stored = :isStored WHERE id = :channelId")
     fun setChannelPinsStored(channelId: Long, isStored: Boolean = true)
 

--- a/app/src/main/java/com/xinto/opencord/db/dao/LastMessageIdsDao.kt
+++ b/app/src/main/java/com/xinto/opencord/db/dao/LastMessageIdsDao.kt
@@ -1,0 +1,25 @@
+package com.xinto.opencord.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.xinto.opencord.db.entity.channel.EntityLastMessageId
+
+@Dao
+interface LastMessageIdsDao {
+    // --------------- Inserts ---------------
+    @Insert(
+        onConflict = OnConflictStrategy.REPLACE,
+        entity = EntityLastMessageId::class,
+    )
+    fun setLastMessageId(data: EntityLastMessageId)
+
+    // --------------- Deletes ---------------
+    @Query("DELETE FROM channels")
+    fun clear()
+
+    // --------------- Queries ---------------
+    @Query("SELECT * FROM last_message_ids WHERE channel_id = :channelId LIMIT 1")
+    fun getLastMessageId(channelId: Long): EntityLastMessageId?
+}

--- a/app/src/main/java/com/xinto/opencord/db/dao/UnreadStatesDao.kt
+++ b/app/src/main/java/com/xinto/opencord/db/dao/UnreadStatesDao.kt
@@ -1,0 +1,28 @@
+package com.xinto.opencord.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.xinto.opencord.db.entity.channel.EntityUnreadState
+
+@Dao
+interface UnreadStatesDao {
+    // --------------- Inserts ---------------
+    @Insert(
+        onConflict = OnConflictStrategy.REPLACE,
+        entity = EntityUnreadState::class,
+    )
+    fun insertUnreadStates(states: List<EntityUnreadState>)
+
+    // --------------- Deletes ---------------
+    @Query("DELETE FROM unread_states WHERE channel_id = :channelId")
+    fun deleteUnreadState(channelId: Long)
+
+    @Query("DELETE FROM channels")
+    fun clear()
+
+    // --------------- Queries ---------------
+    @Query("SELECT * from unread_states WHERE channel_id = :channelId LIMIT 1")
+    fun getUnreadState(channelId: Long): EntityUnreadState?
+}

--- a/app/src/main/java/com/xinto/opencord/db/dao/UnreadStatesDao.kt
+++ b/app/src/main/java/com/xinto/opencord/db/dao/UnreadStatesDao.kt
@@ -15,6 +15,12 @@ interface UnreadStatesDao {
     )
     fun insertUnreadStates(states: List<EntityUnreadState>)
 
+    @Insert(
+        onConflict = OnConflictStrategy.REPLACE,
+        entity = EntityUnreadState::class,
+    )
+    fun insertUnreadState(states: EntityUnreadState)
+
     // --------------- Deletes ---------------
     @Query("DELETE FROM unread_states WHERE channel_id = :channelId")
     fun deleteUnreadState(channelId: Long)

--- a/app/src/main/java/com/xinto/opencord/db/database/CacheDatabase.kt
+++ b/app/src/main/java/com/xinto/opencord/db/database/CacheDatabase.kt
@@ -6,6 +6,8 @@ import androidx.room.TypeConverters
 import com.xinto.opencord.db.Converters
 import com.xinto.opencord.db.dao.*
 import com.xinto.opencord.db.entity.channel.EntityChannel
+import com.xinto.opencord.db.entity.channel.EntityLastMessageId
+import com.xinto.opencord.db.entity.channel.EntityUnreadState
 import com.xinto.opencord.db.entity.guild.EntityGuild
 import com.xinto.opencord.db.entity.message.EntityAttachment
 import com.xinto.opencord.db.entity.message.EntityEmbed
@@ -21,6 +23,8 @@ import com.xinto.opencord.db.entity.user.EntityUser
         EntityEmbed::class,
         EntityMessage::class,
         EntityUser::class,
+        EntityUnreadState::class,
+        EntityLastMessageId::class,
     ],
     exportSchema = false,
 )
@@ -34,4 +38,7 @@ abstract class CacheDatabase : RoomDatabase() {
     abstract fun embeds(): EmbedsDao
 
     abstract fun users(): UsersDao
+
+    abstract fun unreadStates(): UnreadStatesDao
+    abstract fun lastMessageIds(): LastMessageIdsDao
 }

--- a/app/src/main/java/com/xinto/opencord/db/entity/channel/EntityLastMessageId.kt
+++ b/app/src/main/java/com/xinto/opencord/db/entity/channel/EntityLastMessageId.kt
@@ -1,0 +1,19 @@
+package com.xinto.opencord.db.entity.channel
+
+import androidx.compose.runtime.Immutable
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Immutable
+@Entity(
+    tableName = "last_message_ids",
+)
+data class EntityLastMessageId(
+    @PrimaryKey
+    @ColumnInfo(name = "channel_id")
+    val channelId: Long,
+
+    @ColumnInfo(name = "last_message_id")
+    val lastMessageId: Long,
+)

--- a/app/src/main/java/com/xinto/opencord/db/entity/channel/EntityLastMessageId.kt
+++ b/app/src/main/java/com/xinto/opencord/db/entity/channel/EntityLastMessageId.kt
@@ -1,11 +1,9 @@
 package com.xinto.opencord.db.entity.channel
 
-import androidx.compose.runtime.Immutable
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-@Immutable
 @Entity(
     tableName = "last_message_ids",
 )

--- a/app/src/main/java/com/xinto/opencord/db/entity/channel/EntityUnreadState.kt
+++ b/app/src/main/java/com/xinto/opencord/db/entity/channel/EntityUnreadState.kt
@@ -1,0 +1,24 @@
+package com.xinto.opencord.db.entity.channel
+
+import androidx.compose.runtime.Immutable
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import kotlinx.serialization.Serializable
+
+@Immutable
+@Serializable
+@Entity(
+    tableName = "unread_states",
+)
+data class EntityUnreadState(
+    @PrimaryKey
+    @ColumnInfo(name = "channel_id")
+    val channelId: Long,
+
+    @ColumnInfo(name = "mention_count")
+    val mentionCount: Int,
+
+    @ColumnInfo(name = "last_message_id")
+    val lastMessageId: Long,
+)

--- a/app/src/main/java/com/xinto/opencord/db/entity/channel/EntityUnreadState.kt
+++ b/app/src/main/java/com/xinto/opencord/db/entity/channel/EntityUnreadState.kt
@@ -1,13 +1,9 @@
 package com.xinto.opencord.db.entity.channel
 
-import androidx.compose.runtime.Immutable
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import kotlinx.serialization.Serializable
 
-@Immutable
-@Serializable
 @Entity(
     tableName = "unread_states",
 )

--- a/app/src/main/java/com/xinto/opencord/di/HttpModule.kt
+++ b/app/src/main/java/com/xinto/opencord/di/HttpModule.kt
@@ -24,7 +24,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 private typealias OCLogger = com.xinto.opencord.util.Logger
-private typealias KtorLogger = io.ktor.client.plugins.logging.Logger
+private typealias KtorLogger = Logger
 
 val HttpHeaders.XSuperProperties: String
     get() = "X-Super-Properties"

--- a/app/src/main/java/com/xinto/opencord/di/StoreModule.kt
+++ b/app/src/main/java/com/xinto/opencord/di/StoreModule.kt
@@ -66,10 +66,23 @@ val storeModule = module {
         )
     }
 
+    fun provideUnreadStore(
+        gateway: DiscordGateway,
+        api: DiscordApiService,
+        cacheDatabase: CacheDatabase,
+    ): UnreadStore {
+        return UnreadStoreImpl(
+            gateway = gateway,
+            api = api,
+            cache = cacheDatabase,
+        )
+    }
+
     singleOf(::provideMessageStore)
     singleOf(::provideChannelStore)
     singleOf(::provideGuildStore)
     singleOf(::provideUserSettingsStore)
     singleOf(::provideCurrentUserStore)
     singleOf(::provideSessionStore)
+    singleOf(::provideUnreadStore)
 }

--- a/app/src/main/java/com/xinto/opencord/di/ViewModelModule.kt
+++ b/app/src/main/java/com/xinto/opencord/di/ViewModelModule.kt
@@ -60,11 +60,15 @@ val viewModelModule = module {
         persistentDataManager: PersistentDataManager,
         channelStore: ChannelStore,
         guildStore: GuildStore,
+        messageStore: MessageStore,
+        unreadStore: UnreadStore,
     ): ChannelsViewModel {
         return ChannelsViewModel(
             persistentDataManager = persistentDataManager,
             channelStore = channelStore,
             guildStore = guildStore,
+            messageStore = messageStore,
+            unreadStore = unreadStore,
         )
     }
 

--- a/app/src/main/java/com/xinto/opencord/domain/channel/DomainUnreadState.kt
+++ b/app/src/main/java/com/xinto/opencord/domain/channel/DomainUnreadState.kt
@@ -1,0 +1,19 @@
+package com.xinto.opencord.domain.channel
+
+import androidx.compose.runtime.Immutable
+import com.xinto.opencord.db.entity.channel.EntityUnreadState
+
+@Immutable
+data class DomainUnreadState(
+    val channelId: Long,
+    val mentionCount: Int,
+    val lastMessageId: Long,
+)
+
+fun EntityUnreadState.toDomain(): DomainUnreadState {
+    return DomainUnreadState(
+        channelId = channelId,
+        mentionCount = mentionCount,
+        lastMessageId = lastMessageId,
+    )
+}

--- a/app/src/main/java/com/xinto/opencord/gateway/dto/MessageAckData.kt
+++ b/app/src/main/java/com/xinto/opencord/gateway/dto/MessageAckData.kt
@@ -1,0 +1,21 @@
+package com.xinto.opencord.gateway.dto
+
+import kotlinx.serialization.SerialName
+
+@kotlinx.serialization.Serializable
+data class MessageAckData(
+    @SerialName("ack_type")
+    val ackType: Int? = null,
+
+    @SerialName("channel_id")
+    val channelId: Long,
+
+    @SerialName("message_id")
+    val messageId: Long,
+
+    @SerialName("version")
+    val version: Int,
+
+    @SerialName("mention_count")
+    val mentionCount: Int? = 0,
+)

--- a/app/src/main/java/com/xinto/opencord/gateway/dto/MessageAckData.kt
+++ b/app/src/main/java/com/xinto/opencord/gateway/dto/MessageAckData.kt
@@ -1,8 +1,9 @@
 package com.xinto.opencord.gateway.dto
 
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-@kotlinx.serialization.Serializable
+@Serializable
 data class MessageAckData(
     @SerialName("ack_type")
     val ackType: Int? = null,

--- a/app/src/main/java/com/xinto/opencord/gateway/dto/Ready.kt
+++ b/app/src/main/java/com/xinto/opencord/gateway/dto/Ready.kt
@@ -3,6 +3,7 @@ package com.xinto.opencord.gateway.dto
 import com.xinto.opencord.rest.models.ApiGuild
 import com.xinto.opencord.rest.models.user.ApiUser
 import com.xinto.opencord.rest.models.user.settings.ApiUserSettings
+import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -22,4 +23,29 @@ data class Ready(
 
     @SerialName("user_settings")
     val userSettings: ApiUserSettings,
+
+    @SerialName("read_state")
+    val readState: ReadState
+)
+
+@Serializable
+data class ReadState(
+    val version: Int,
+    val partial: Boolean,
+    val entries: List<ReadStateEntry>
+)
+
+@Serializable
+data class ReadStateEntry(
+    @SerialName("id")
+    val channelId: Long,
+
+    @SerialName("mention_count")
+    val mentionCount: Int,
+
+    @SerialName("last_pin_timestamp")
+    val lastPinTimestamp: Instant,
+
+    @SerialName("last_message_id")
+    val lastMessageId: Long,
 )

--- a/app/src/main/java/com/xinto/opencord/gateway/event/Event.kt
+++ b/app/src/main/java/com/xinto/opencord/gateway/event/Event.kt
@@ -1,9 +1,6 @@
 package com.xinto.opencord.gateway.event
 
-import com.xinto.opencord.gateway.dto.GuildDeleteData
-import com.xinto.opencord.gateway.dto.MessageDeleteData
-import com.xinto.opencord.gateway.dto.Ready
-import com.xinto.opencord.gateway.dto.SessionData
+import com.xinto.opencord.gateway.dto.*
 import com.xinto.opencord.gateway.io.EventName
 import com.xinto.opencord.rest.models.ApiChannel
 import com.xinto.opencord.rest.models.ApiGuild
@@ -86,6 +83,11 @@ class EventDeserializationStrategy(
             EventName.MessageDelete -> {
                 MessageDeleteEvent(
                     data = decoder.decodeSerializableValue(MessageDeleteData.serializer()),
+                )
+            }
+            EventName.MessageAck -> {
+                MessageAckEvent(
+                    data = decoder.decodeSerializableValue(MessageAckData.serializer()),
                 )
             }
             EventName.SessionsReplace -> {

--- a/app/src/main/java/com/xinto/opencord/gateway/event/Message.kt
+++ b/app/src/main/java/com/xinto/opencord/gateway/event/Message.kt
@@ -1,5 +1,6 @@
 package com.xinto.opencord.gateway.event
 
+import com.xinto.opencord.gateway.dto.MessageAckData
 import com.xinto.opencord.gateway.dto.MessageDeleteData
 import com.xinto.opencord.rest.models.message.ApiMessage
 import com.xinto.opencord.rest.models.message.ApiMessagePartial
@@ -14,4 +15,8 @@ data class MessageUpdateEvent(
 
 data class MessageDeleteEvent(
     val data: MessageDeleteData,
+) : Event
+
+data class MessageAckEvent(
+    val data: MessageAckData,
 ) : Event

--- a/app/src/main/java/com/xinto/opencord/gateway/io/EventName.kt
+++ b/app/src/main/java/com/xinto/opencord/gateway/io/EventName.kt
@@ -23,6 +23,7 @@ enum class EventName(val eventName: String) {
     MessageCreate("MESSAGE_CREATE"),
     MessageUpdate("MESSAGE_UPDATE"),
     MessageDelete("MESSAGE_DELETE"),
+    MessageAck("MESSAGE_ACK"),
     SessionsReplace("SESSIONS_REPLACE"),
     GuildMemberChunk("GUILD_MEMBER_CHUNK"),
     UserSettingsUpdate("USER_SETTINGS_UPDATE"),

--- a/app/src/main/java/com/xinto/opencord/rest/models/ApiChannel.kt
+++ b/app/src/main/java/com/xinto/opencord/rest/models/ApiChannel.kt
@@ -25,4 +25,7 @@ data class ApiChannel(
 
     @SerialName("nsfw")
     val nsfw: Boolean = false,
+
+    @SerialName("last_message_id")
+    val lastMessageId: ApiSnowflake? = null,
 )

--- a/app/src/main/java/com/xinto/opencord/store/UnreadStore.kt
+++ b/app/src/main/java/com/xinto/opencord/store/UnreadStore.kt
@@ -69,7 +69,7 @@ class UnreadStoreImpl(
             )
 
             events.emit(UnreadEvent.Add(state.toDomain()))
-            cache.unreadStates().insertUnreadStates(listOf(state))
+            cache.unreadStates().insertUnreadState(state)
         }
 
         gateway.onEvent<ChannelDeleteEvent> { event ->

--- a/app/src/main/java/com/xinto/opencord/store/UnreadStore.kt
+++ b/app/src/main/java/com/xinto/opencord/store/UnreadStore.kt
@@ -1,0 +1,80 @@
+package com.xinto.opencord.store
+
+import androidx.room.withTransaction
+import com.xinto.opencord.db.database.CacheDatabase
+import com.xinto.opencord.db.entity.channel.EntityUnreadState
+import com.xinto.opencord.gateway.DiscordGateway
+import com.xinto.opencord.gateway.event.ChannelDeleteEvent
+import com.xinto.opencord.gateway.event.MessageAckEvent
+import com.xinto.opencord.gateway.event.ReadyEvent
+import com.xinto.opencord.gateway.onEvent
+import com.xinto.opencord.rest.service.DiscordApiService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.filter
+
+typealias UnreadEvent = Event<EntityUnreadState, Nothing, Long>
+
+interface UnreadStore {
+    fun observeChannel(channelId: Long): Flow<UnreadEvent>
+
+    suspend fun getChannel(channelId: Long): EntityUnreadState?
+}
+
+class UnreadStoreImpl(
+    gateway: DiscordGateway,
+    private val api: DiscordApiService,
+    private val cache: CacheDatabase,
+) : UnreadStore {
+    private val events = MutableSharedFlow<UnreadEvent>()
+
+    override fun observeChannel(channelId: Long): Flow<UnreadEvent> {
+        return events.filter { event ->
+            event.fold(
+                onAdd = { it.channelId == channelId },
+                onUpdate = { false },
+                onDelete = { it == channelId },
+            )
+        }
+    }
+
+    override suspend fun getChannel(channelId: Long): EntityUnreadState? {
+        return cache.unreadStates().getUnreadState(channelId)
+    }
+
+    init {
+        gateway.onEvent<ReadyEvent> { event ->
+            val states = event.data.readState.entries.map {
+                EntityUnreadState(
+                    channelId = it.channelId,
+                    mentionCount = it.mentionCount,
+                    lastMessageId = it.lastMessageId,
+                )
+            }
+
+            states.forEach { events.emit(UnreadEvent.Add(it)) }
+            cache.withTransaction {
+                cache.unreadStates().clear()
+                cache.unreadStates().insertUnreadStates(states)
+            }
+        }
+
+        gateway.onEvent<MessageAckEvent> { event ->
+            val state = EntityUnreadState(
+                channelId = event.data.channelId,
+                mentionCount = event.data.mentionCount ?: 0,
+                lastMessageId = event.data.messageId,
+            )
+
+            events.emit(UnreadEvent.Add(state))
+            cache.unreadStates().insertUnreadStates(listOf(state))
+        }
+
+        gateway.onEvent<ChannelDeleteEvent> { event ->
+            val channelId = event.data.id.value
+
+            events.emit(UnreadEvent.Delete(channelId))
+            cache.unreadStates().deleteUnreadState(channelId)
+        }
+    }
+}

--- a/app/src/main/java/com/xinto/opencord/ui/components/channel/list/ChannelListRegularItem.kt
+++ b/app/src/main/java/com/xinto/opencord/ui/components/channel/list/ChannelListRegularItem.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.xinto.opencord.ui.components.indicator.UnreadIndicator
+import com.xinto.opencord.ui.util.ContentAlpha
+import com.xinto.opencord.ui.util.ProvideContentAlpha
 
 @Composable
 fun ChannelListRegularItem(
@@ -49,19 +51,21 @@ fun ChannelListRegularItem(
             onClick = onClick,
             tonalElevation = tonalElevation,
         ) {
-            Row(
-                modifier = Modifier.padding(6.dp),
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Box(
-                    modifier = Modifier.size(24.dp),
-                    contentAlignment = Alignment.Center,
+            ProvideContentAlpha(if (selected || showUnread) ContentAlpha.full else ContentAlpha.medium) {
+                Row(
+                    modifier = Modifier.padding(6.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    icon()
-                }
-                ProvideTextStyle(MaterialTheme.typography.titleMedium) {
-                    title()
+                    Box(
+                        modifier = Modifier.size(24.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        icon()
+                    }
+                    ProvideTextStyle(MaterialTheme.typography.titleMedium) {
+                        title()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/xinto/opencord/ui/components/channel/list/ChannelListRegularItem.kt
+++ b/app/src/main/java/com/xinto/opencord/ui/components/channel/list/ChannelListRegularItem.kt
@@ -22,7 +22,7 @@ fun ChannelListRegularItem(
     title: @Composable () -> Unit,
     icon: @Composable () -> Unit,
     selected: Boolean,
-    showIndicator: Boolean,
+    showUnread: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val indicatorFraction by animateFloatAsState(if (selected) 0.7f else 0.15f)
@@ -33,7 +33,7 @@ fun ChannelListRegularItem(
     ) {
         AnimatedVisibility(
             modifier = Modifier.align(Alignment.CenterStart),
-            visible = showIndicator || selected,
+            visible = selected || showUnread,
             enter = slideInHorizontally(),
             exit = slideOutHorizontally(),
         ) {

--- a/app/src/main/java/com/xinto/opencord/ui/components/message/MessageRegular.kt
+++ b/app/src/main/java/com/xinto/opencord/ui/components/message/MessageRegular.kt
@@ -65,13 +65,13 @@ fun MessageRegular(
             ) {
                 if (avatar != null) {
                     Box(
-                        modifier = androidx.compose.ui.Modifier.size(40.dp),
+                        modifier = Modifier.size(40.dp),
                         contentAlignment = Alignment.Center,
                     ) {
                         avatar()
                     }
                 } else {
-                    Spacer(modifier = androidx.compose.ui.Modifier.width(40.dp))
+                    Spacer(modifier = Modifier.width(40.dp))
                 }
                 Column(
                     modifier = Modifier.weight(1f),

--- a/app/src/main/java/com/xinto/opencord/ui/screens/home/panels/channel/ChannelsList.kt
+++ b/app/src/main/java/com/xinto/opencord/ui/screens/home/panels/channel/ChannelsList.kt
@@ -29,6 +29,16 @@ fun ChannelsList(
             viewModel.collapsedCategories.toImmutableList()
         }
     }
+    val unreadStates by remember(viewModel.unreadStates) {
+        derivedStateOf {
+            viewModel.unreadStates.toImmutableMap()
+        }
+    }
+    val lastMessageIds by remember(viewModel.lastMessageIds) {
+        derivedStateOf {
+            viewModel.lastMessageIds.toImmutableMap()
+        }
+    }
 
     CompositionLocalProvider(LocalAbsoluteTonalElevation provides 1.dp) {
         Surface(
@@ -60,6 +70,8 @@ fun ChannelsList(
                         boostLevel = viewModel.guildBoostLevel,
                         guildName = viewModel.guildName,
                         channels = sortedChannels,
+                        unreadStates = unreadStates,
+                        lastMessageIds = lastMessageIds,
                         collapsedCategories = collapsedCategories,
                         selectedChannelId = viewModel.selectedChannelId,
                     )

--- a/app/src/main/java/com/xinto/opencord/ui/screens/home/panels/channel/ChannelsListLoaded.kt
+++ b/app/src/main/java/com/xinto/opencord/ui/screens/home/panels/channel/ChannelsListLoaded.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.xinto.opencord.R
+import com.xinto.opencord.db.entity.channel.EntityUnreadState
 import com.xinto.opencord.domain.channel.DomainCategoryChannel
 import com.xinto.opencord.domain.channel.DomainChannel
 import com.xinto.opencord.domain.channel.DomainTextChannel
@@ -47,6 +48,8 @@ fun ChannelsListLoaded(
     boostLevel: Int,
     guildName: String,
     channels: ImmutableMap<DomainCategoryChannel?, ImmutableList<DomainChannel>>,
+    unreadStates: ImmutableMap<Long, EntityUnreadState>,
+    lastMessageIds: ImmutableMap<Long, Long>,
     collapsedCategories: ImmutableList<Long>,
     modifier: Modifier = Modifier
 ) {
@@ -173,7 +176,7 @@ fun ChannelsListLoaded(
                                     )
                                 },
                                 selected = selectedChannelId == channel.id,
-                                showIndicator = selectedChannelId != channel.id,
+                                showUnread = (unreadStates[channel.id]?.lastMessageId ?: -1) < (lastMessageIds[channel.id] ?: 0),
                                 onClick = {
                                     onChannelSelect(channel.id)
                                 },
@@ -190,7 +193,7 @@ fun ChannelsListLoaded(
                                     )
                                 },
                                 selected = false,
-                                showIndicator = false,
+                                showUnread = false,
                                 onClick = { /*TODO*/ },
                             )
                         }

--- a/app/src/main/java/com/xinto/opencord/ui/screens/home/panels/channel/ChannelsListLoaded.kt
+++ b/app/src/main/java/com/xinto/opencord/ui/screens/home/panels/channel/ChannelsListLoaded.kt
@@ -26,11 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.xinto.opencord.R
-import com.xinto.opencord.db.entity.channel.EntityUnreadState
-import com.xinto.opencord.domain.channel.DomainCategoryChannel
-import com.xinto.opencord.domain.channel.DomainChannel
-import com.xinto.opencord.domain.channel.DomainTextChannel
-import com.xinto.opencord.domain.channel.DomainVoiceChannel
+import com.xinto.opencord.domain.channel.*
 import com.xinto.opencord.ui.components.OCAsyncImage
 import com.xinto.opencord.ui.components.channel.list.ChannelListCategoryItem
 import com.xinto.opencord.ui.components.channel.list.ChannelListRegularItem
@@ -48,7 +44,7 @@ fun ChannelsListLoaded(
     boostLevel: Int,
     guildName: String,
     channels: ImmutableMap<DomainCategoryChannel?, ImmutableList<DomainChannel>>,
-    unreadStates: ImmutableMap<Long, EntityUnreadState>,
+    unreadStates: ImmutableMap<Long, DomainUnreadState>,
     lastMessageIds: ImmutableMap<Long, Long>,
     collapsedCategories: ImmutableList<Long>,
     modifier: Modifier = Modifier

--- a/app/src/main/java/com/xinto/opencord/ui/screens/home/panels/channel/ChannelsListLoading.kt
+++ b/app/src/main/java/com/xinto/opencord/ui/screens/home/panels/channel/ChannelsListLoading.kt
@@ -103,7 +103,7 @@ fun ChannelsListLoading(
                         )
                     },
                     selected = false,
-                    showIndicator = false,
+                    showUnread = false,
                     onClick = {},
                 )
             }

--- a/app/src/main/java/com/xinto/opencord/ui/viewmodel/ChannelsViewModel.kt
+++ b/app/src/main/java/com/xinto/opencord/ui/viewmodel/ChannelsViewModel.kt
@@ -2,12 +2,11 @@ package com.xinto.opencord.ui.viewmodel
 
 import androidx.compose.runtime.*
 import androidx.lifecycle.viewModelScope
+import com.xinto.opencord.db.entity.channel.EntityUnreadState
 import com.xinto.opencord.domain.channel.DomainCategoryChannel
 import com.xinto.opencord.domain.channel.DomainChannel
 import com.xinto.opencord.manager.PersistentDataManager
-import com.xinto.opencord.store.ChannelStore
-import com.xinto.opencord.store.GuildStore
-import com.xinto.opencord.store.fold
+import com.xinto.opencord.store.*
 import com.xinto.opencord.ui.viewmodel.base.BasePersistenceViewModel
 import com.xinto.opencord.util.collectIn
 import com.xinto.opencord.util.getSortedChannels
@@ -19,6 +18,8 @@ class ChannelsViewModel(
     persistentDataManager: PersistentDataManager,
     private val channelStore: ChannelStore,
     private val guildStore: GuildStore,
+    private val messageStore: MessageStore,
+    private val unreadStore: UnreadStore,
 ) : BasePersistenceViewModel(persistentDataManager) {
     sealed interface State {
         object Unselected : State
@@ -30,18 +31,23 @@ class ChannelsViewModel(
     var state by mutableStateOf<State>(State.Unselected)
         private set
 
+    var selectedChannelId by mutableStateOf(0L)
+        private set
+
     val channels = mutableStateMapOf<Long, DomainChannel>()
+    val unreadStates = mutableStateMapOf<Long, EntityUnreadState>()
+    val collapsedCategories = mutableStateListOf<Long>()
+    val lastMessageIds = mutableStateMapOf<Long, Long>()
+
     var guildName by mutableStateOf("")
         private set
     var guildBannerUrl by mutableStateOf<String?>(null)
         private set
     var guildBoostLevel by mutableStateOf(0)
-
-    var selectedChannelId by mutableStateOf(0L)
         private set
-    val collapsedCategories = mutableStateListOf<Long>()
 
     fun load() {
+//        viewModelScope.cancel()
         viewModelScope.launch {
             state = State.Loading
             withContext(Dispatchers.IO) {
@@ -49,13 +55,45 @@ class ChannelsViewModel(
                     val guild = guildStore.fetchGuild(persistentGuildId) ?: return@withContext
                     val guildChannels = channelStore.fetchChannels(persistentGuildId)
                         .associateBy { it.id }
+                    val states = guildChannels.keys
+                        .mapNotNull { unreadStore.getChannel(it) }
+                        .associateBy { it.channelId }
+                    val lastMessages = guildChannels.keys.mapNotNull {
+                        val message = messageStore.getLastMessageId(it) ?: return@mapNotNull null
+                        it to message
+                    }
+
+                    for (channelId in guildChannels.keys) {
+                        unreadStore.observeChannel(channelId).collectIn(viewModelScope) { event ->
+                            event.fold(
+                                onAdd = { unreadStates[it.channelId] = it },
+                                onUpdate = { },
+                                onDelete = { unreadStates.remove(it) },
+                            )
+                        }
+                        messageStore.observeChannel(channelId).collectIn(viewModelScope) { event ->
+                            event.fold(
+                                onAdd = { lastMessageIds[it.channelId] = it.id },
+                                onUpdate = { },
+                                onDelete = { },
+                            )
+                        }
+                    }
 
                     withContext(Dispatchers.Main) {
                         channels.clear()
                         channels.putAll(guildChannels)
+
+                        unreadStates.clear()
+                        unreadStates.putAll(states)
+
+                        lastMessageIds.clear()
+                        lastMessageIds.putAll(lastMessages)
+
                         guildName = guild.name
                         guildBannerUrl = guild.bannerUrl
                         guildBoostLevel = guild.premiumTier
+
                         state = State.Loaded
                     }
                 } catch (e: Exception) {
@@ -90,7 +128,10 @@ class ChannelsViewModel(
             event.fold(
                 onAdd = { channels[it.id] = it },
                 onUpdate = { channels[it.id] = it },
-                onDelete = { channels.remove(it) },
+                onDelete = {
+                    channels.remove(it)
+                    lastMessageIds.remove(it)
+                },
             )
         }
     }

--- a/app/src/main/java/com/xinto/opencord/ui/viewmodel/ChannelsViewModel.kt
+++ b/app/src/main/java/com/xinto/opencord/ui/viewmodel/ChannelsViewModel.kt
@@ -2,9 +2,9 @@ package com.xinto.opencord.ui.viewmodel
 
 import androidx.compose.runtime.*
 import androidx.lifecycle.viewModelScope
-import com.xinto.opencord.db.entity.channel.EntityUnreadState
 import com.xinto.opencord.domain.channel.DomainCategoryChannel
 import com.xinto.opencord.domain.channel.DomainChannel
+import com.xinto.opencord.domain.channel.DomainUnreadState
 import com.xinto.opencord.manager.PersistentDataManager
 import com.xinto.opencord.store.*
 import com.xinto.opencord.ui.viewmodel.base.BasePersistenceViewModel
@@ -35,7 +35,7 @@ class ChannelsViewModel(
         private set
 
     val channels = mutableStateMapOf<Long, DomainChannel>()
-    val unreadStates = mutableStateMapOf<Long, EntityUnreadState>()
+    val unreadStates = mutableStateMapOf<Long, DomainUnreadState>()
     val collapsedCategories = mutableStateListOf<Long>()
     val lastMessageIds = mutableStateMapOf<Long, Long>()
 


### PR DESCRIPTION
Adds support for unread indicators logic

Due to the way they work, we need to provide both the last message id of a channel and the read state for it (last read message id & mention count)

I decoupled the lastMessageId from DomainChannel to avoid unnecessary updates and made it be stored separately in MessageStore. A flow for "new message ids" isn't really needed because we already essentially have one, that being the regular message event which the ChannelViewModel now subscribes to

Mention count & marking a channel read will come later 